### PR TITLE
fix: counter.inc should only allow incrementing by values greather th…

### DIFF
--- a/prometheus_client/CHANGELOG.md
+++ b/prometheus_client/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.4.1
+
+- `counter.inc()` should only allow to increment by values greather than zero.
+
 ## 0.4.0+4
 
-- Moved to new org [tentaclelabs](https://github.com/tentaclelabs)
+- Moved to new org [tentaclelabs](https://github.com/tentaclelabs).
 
 
 ## 0.4.0+3

--- a/prometheus_client/lib/src/prometheus_client/counter.dart
+++ b/prometheus_client/lib/src/prometheus_client/counter.dart
@@ -39,9 +39,9 @@ class CounterChild {
   /// Increment the [value] of the counter with labels by [amount].
   /// Increments by one, if no amount is provided.
   void inc([double amount = 1]) {
-    if (amount < 0) {
+    if (amount <= 0) {
       throw ArgumentError.value(
-          amount, 'amount', 'Must be greater or equal to zero.');
+          amount, 'amount', 'Must be greater than zero.');
     }
 
     _value += amount;

--- a/prometheus_client/pubspec.yaml
+++ b/prometheus_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: prometheus_client
 description: Dart implementation of the Prometheus client library providing metrics.
-version: 0.4.0+4
+version: 0.4.1
 homepage: https://github.com/tentaclelabs/prometheus_client
 
 environment:

--- a/prometheus_client/test/prometheus_client_counter_test.dart
+++ b/prometheus_client/test/prometheus_client_counter_test.dart
@@ -41,6 +41,12 @@ void main() {
       expect(() => counter.inc(-42.0), throwsArgumentError);
     });
 
+    test('Should not increment by zero', () {
+      final counter = Counter('my_metric', 'Help!');
+
+      expect(() => counter.inc(0.0), throwsArgumentError);
+    });
+
     test('Should not allow to set label values if no labels were specified',
         () {
       final counter = Counter('my_metric', 'Help!');

--- a/prometheus_client_shelf/CHANGELOG.md
+++ b/prometheus_client_shelf/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+No changes
+
 ## 0.4.0+4
 
 - Moved to new org [tentaclelabs](https://github.com/tentaclelabs)

--- a/prometheus_client_shelf/pubspec.yaml
+++ b/prometheus_client_shelf/pubspec.yaml
@@ -1,6 +1,6 @@
 name: prometheus_client_shelf
 description: Dart implementation of the Prometheus client library providing a shelf integration.
-version: 0.4.0+4
+version: 0.4.1
 homepage: https://github.com/tentaclelabs/prometheus_client
 
 environment:


### PR DESCRIPTION
…an zero

Spec says:

> inc(double v): Increment the counter by the given amount. MUST check that v >= 0.

https://prometheus.io/docs/instrumenting/writing_clientlibs/